### PR TITLE
Fix function name in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ be performed, and the results object will only contain partial results.
 ```js
 var auto = require('run-auto')
 
-async.auto({
+auto({
   getData: function (callback) {
     console.log('in getData')
     // async code to get some data


### PR DESCRIPTION
Hey Feross!

I fixed a small oversight that I found in the `auto` function call of the README's example code.

Thanks for this cool module! Go modularity!
